### PR TITLE
Reattaching the service to the compute node

### DIFF
--- a/container/controller/controller/runtime.py
+++ b/container/controller/controller/runtime.py
@@ -62,7 +62,6 @@ spec:
         app: compute
         domain: {DOMNAME}
     spec:
-      hostNetwork: True
       volumes:
       - name: host
         hostPath:


### PR DESCRIPTION
The service now can find the compute nodes after
the ports can only be found if the not on the host itself

Signed-off-by: Tolik Litovsky tlitovsk@redhat.com
